### PR TITLE
Revert "kernel: printk: Allow logging to be toggled via sysfs"

### DIFF
--- a/kernel/printk/printk.c
+++ b/kernel/printk/printk.c
@@ -59,9 +59,6 @@
 extern void printascii(char *);
 #endif
 
-static __read_mostly bool enabled;
-module_param(enabled, bool, S_IRUGO | S_IWUSR);
-
 int console_printk[4] = {
 	CONSOLE_LOGLEVEL_DEFAULT,	/* console_loglevel */
 	MESSAGE_LOGLEVEL_DEFAULT,	/* default_message_loglevel */
@@ -1696,9 +1693,6 @@ asmlinkage int vprintk_emit(int facility, int level,
 	/* cpu currently holding logbuf_lock in this function */
 	static unsigned int logbuf_cpu = UINT_MAX;
 
-	if (!enabled)
-		return 0;
-
 	if (level == LOGLEVEL_SCHED) {
 		level = LOGLEVEL_DEFAULT;
 		in_sched = true;
@@ -1863,9 +1857,6 @@ EXPORT_SYMBOL(vprintk_emit);
 
 asmlinkage int vprintk(const char *fmt, va_list args)
 {
-	if (!enabled)
-		return 0;
-
 	return vprintk_emit(0, LOGLEVEL_DEFAULT, NULL, 0, fmt, args);
 }
 EXPORT_SYMBOL(vprintk);
@@ -1876,9 +1867,6 @@ asmlinkage int printk_emit(int facility, int level,
 {
 	va_list args;
 	int r;
-
-	if (!enabled)
-		return 0;
 
 	va_start(args, fmt);
 	r = vprintk_emit(facility, level, dict, dictlen, fmt, args);
@@ -1891,9 +1879,6 @@ EXPORT_SYMBOL(printk_emit);
 int vprintk_default(const char *fmt, va_list args)
 {
 	int r;
-
-	if (!enabled)
-		return 0;
 
 #ifdef CONFIG_KGDB_KDB
 	if (unlikely(kdb_trap_printk)) {
@@ -1941,9 +1926,6 @@ asmlinkage __visible int printk(const char *fmt, ...)
 	printk_func_t vprintk_func;
 	va_list args;
 	int r;
-
-	if (!enabled)
-		return 0;
 
 	va_start(args, fmt);
 


### PR DESCRIPTION
This reverts commit 808f671c19fd8c1cab805a2e86239fb2b3c4d39b.

Signed-off-by: sohamxda7 <sensoham135@gmail.com>